### PR TITLE
added install command for scipy

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 
 apt-get update -y && apt-get install -y vim
-pip install ipython numpy pyreadline jupyter quandl scikit-learn matplotlib
+pip install ipython numpy pyreadline jupyter quandl scipy scikit-learn matplotlib
 
 mkdir -p /root/.jupyter
 echo "


### PR DESCRIPTION
Probably, `setup.sh` needs scipy :)

```
  Running setup.py bdist_wheel for scikit-learn ... error
  Complete output from command /usr/local/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-us15gwux/scikit-learn/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpbz0084r1pip-wheel- --python-tag cp36:
  Partial import of sklearn during the build process.
  Traceback (most recent call last):
    File "/tmp/pip-build-us15gwux/scikit-learn/setup.py", line 149, in get_scipy_status
      import scipy
  ModuleNotFoundError: No module named 'scipy'
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-build-us15gwux/scikit-learn/setup.py", line 270, in <module>
      setup_package()
    File "/tmp/pip-build-us15gwux/scikit-learn/setup.py", line 260, in setup_package
      .format(scipy_req_str, instructions))
  ImportError: Scientific Python (SciPy) is not installed.
  scikit-learn requires SciPy >= 0.9.
  Installation instructions are available on the scikit-learn website: http://scikit-learn.org/stable/install.html


  ----------------------------------------

  Failed building wheel for scikit-learn
  Running setup.py clean for scikit-learn
Failed to build scikit-learn
Installing collected packages: scikit-learn, pyparsing, cycler, matplotlib
  Running setup.py install for scikit-learn ... error
    Complete output from command /usr/local/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-us15gwux/scikit-learn/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-gk4n55pp-record/install-record.txt --single-version-externally-managed --compile:
    Partial import of sklearn during the build process.
    Traceback (most recent call last):
      File "/tmp/pip-build-us15gwux/scikit-learn/setup.py", line 149, in get_scipy_status
        import scipy
    ModuleNotFoundError: No module named 'scipy'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-us15gwux/scikit-learn/setup.py", line 270, in <module>
        setup_package()
      File "/tmp/pip-build-us15gwux/scikit-learn/setup.py", line 260, in setup_package
        .format(scipy_req_str, instructions))
    ImportError: Scientific Python (SciPy) is not installed.
    scikit-learn requires SciPy >= 0.9.
    Installation instructions are available on the scikit-learn website: http://scikit-learn.org/stable/install.html


    ----------------------------------------
Command "/usr/local/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-us15gwux/scikit-learn/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-gk4n55pp-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-us15gwux/scikit-learn/
```